### PR TITLE
Filter expression in comboBox

### DIFF
--- a/components/AttributeForm.jsx
+++ b/components/AttributeForm.jsx
@@ -145,7 +145,7 @@ class AttributeForm extends React.Component {
                 ) : null}
                 <form action="" onChange={ev => this.formChanged(ev)} onSubmit={this.onSubmit} ref={this.setupChangedObserver}>
                     {this.props.editConfig.form ? (
-                        <QtDesignerForm addRelationRecord={this.addRelationRecord} editLayerId={this.props.editConfig.editDataset}
+                        <QtDesignerForm addRelationRecord={this.addRelationRecord} editConfig={this.props.theme.editConfig} editLayerId={this.props.editConfig.editDataset}
                             editRelationRecord={this.editRelationRecord} feature={this.props.editContext.feature}
                             fields={this.fieldsMap(this.props.editConfig.fields)} form={this.props.editConfig.form} iface={this.props.iface}
                             mapCrs={this.props.map.projection} mapPrefix={this.editMapPrefix()} readOnly={readOnly}

--- a/components/QtDesignerForm.jsx
+++ b/components/QtDesignerForm.jsx
@@ -390,15 +390,21 @@ class QtDesignerForm extends React.Component {
                 // kvrel__attrname__datatable__keyfield__valuefield
                 // kvrel__reltablename__attrname__datatable__keyfield__valuefield
                 const count = parts.length;
-                const attrname = parts.slice(1, count - 3).join("__");
-                const currentEditConfig = this.props.editConfig[parts[1]];
-                const comboFieldConstraints = currentEditConfig.fields.find(field => field.id === attrname.split("__")[1])?.constraints || {};
-                value = (feature.properties || [])[attrname] ?? "";
+                const attrname = parts.slice(1, count - 3)[parts.slice(1, count - 3).length === 1 ? 0 : 1];
                 const fieldId = parts.slice(1, count - 3).join("__");
+                value = (feature.properties || [])[fieldId] ?? "";
                 const keyvalrel = this.props.mapPrefix + parts[count - 3] + ":" + parts[count - 2] + ":" + parts[count - 1];
                 let filterExpr = null;
-                if (currentEditConfig.fields.find(field => field.id === attrname.split("__")[1])?.filterExpression) {
-                    filterExpr = parseExpression(currentEditConfig.fields.find(field => field.id === attrname.split("__")[1]).filterExpression, feature, this.props.iface, this.props.mapPrefix, this.props.mapCrs, () => this.setState({reevaluate: +new Date}), true);
+                let currentLayerId = null;
+                if (count === 5) {
+                    currentLayerId = this.props.editLayerId.split(".")[1];
+                } else {
+                    currentLayerId = parts[1];
+                }
+                const currentEditConfig = this.props.editConfig[currentLayerId];
+                const comboFieldConstraints = currentEditConfig.fields.find(field => field.id === attrname)?.constraints || {};
+                if (currentEditConfig.fields.find(field => field.id === attrname)?.filterExpression) {
+                    filterExpr = parseExpression(currentEditConfig.fields.find(field => field.id === attrname).filterExpression, feature, this.props.iface, this.props.mapPrefix, this.props.mapCrs, () => this.setState({reevaluate: +new Date}), true);
                 }
                 return (
                     <EditComboField

--- a/components/QtDesignerForm.jsx
+++ b/components/QtDesignerForm.jsx
@@ -73,6 +73,7 @@ class QtDesignerForm extends React.Component {
         setFormBusy: PropTypes.func,
         setRelationTables: PropTypes.func,
         switchEditContext: PropTypes.func,
+        theme: PropTypes.object,
         updateField: PropTypes.func,
         updateRelationField: PropTypes.func
     };
@@ -390,13 +391,14 @@ class QtDesignerForm extends React.Component {
                 // kvrel__reltablename__attrname__datatable__keyfield__valuefield
                 const count = parts.length;
                 const attrname = parts.slice(1, count - 3).join("__");
-                const comboFieldConstraints = this.props.fields[attrname]?.constraints || {};
+                const currentEditConfig = this.props.theme.editConfig[parts[1]];
+                const comboFieldConstraints = currentEditConfig.fields.find(field => field.id === attrname.split("__")[1])?.constraints || {};
                 value = (feature.properties || [])[attrname] ?? "";
                 const fieldId = parts.slice(1, count - 3).join("__");
                 const keyvalrel = this.props.mapPrefix + parts[count - 3] + ":" + parts[count - 2] + ":" + parts[count - 1];
                 let filterExpr = null;
-                if (this.props.fields[attrname]?.filterExpression) {
-                    filterExpr = parseExpression(this.props.fields[attrname].filterExpression, feature, this.props.iface, this.props.mapPrefix, this.props.mapCrs, () => this.setState({reevaluate: +new Date}), true);
+                if (currentEditConfig.fields.find(field => field.id === attrname.split("__")[1])?.filterExpression) {
+                    filterExpr = parseExpression(currentEditConfig.fields.find(field => field.id === attrname.split("__")[1]).filterExpression, feature, this.props.iface, this.props.mapPrefix, this.props.mapCrs, () => this.setState({reevaluate: +new Date}), true);
                 }
                 return (
                     <EditComboField
@@ -783,6 +785,7 @@ class QtDesignerForm extends React.Component {
 }
 
 export default connect((state) => ({
-    locale: state.locale.current
+    locale: state.locale.current,
+    theme: state.theme.current
 }), {
 })(QtDesignerForm);

--- a/components/QtDesignerForm.jsx
+++ b/components/QtDesignerForm.jsx
@@ -57,6 +57,7 @@ const vFitWidgets = ["QLabel", "QCheckBox", "QRadioButton", "Line", "QDateTimeEd
 class QtDesignerForm extends React.Component {
     static propTypes = {
         addRelationRecord: PropTypes.func,
+        editConfig: PropTypes.object,
         editLayerId: PropTypes.string,
         editRelationRecord: PropTypes.func,
         feature: PropTypes.object,
@@ -73,7 +74,6 @@ class QtDesignerForm extends React.Component {
         setFormBusy: PropTypes.func,
         setRelationTables: PropTypes.func,
         switchEditContext: PropTypes.func,
-        theme: PropTypes.object,
         updateField: PropTypes.func,
         updateRelationField: PropTypes.func
     };
@@ -391,7 +391,7 @@ class QtDesignerForm extends React.Component {
                 // kvrel__reltablename__attrname__datatable__keyfield__valuefield
                 const count = parts.length;
                 const attrname = parts.slice(1, count - 3).join("__");
-                const currentEditConfig = this.props.theme.editConfig[parts[1]];
+                const currentEditConfig = this.props.editConfig[parts[1]];
                 const comboFieldConstraints = currentEditConfig.fields.find(field => field.id === attrname.split("__")[1])?.constraints || {};
                 value = (feature.properties || [])[attrname] ?? "";
                 const fieldId = parts.slice(1, count - 3).join("__");
@@ -785,7 +785,6 @@ class QtDesignerForm extends React.Component {
 }
 
 export default connect((state) => ({
-    locale: state.locale.current,
-    theme: state.theme.current
+    locale: state.locale.current
 }), {
 })(QtDesignerForm);


### PR DESCRIPTION
The filter expressions are stored in the editConfig and not in the fields in the mapViewerConfig. So the filter expression configured in qgis relational fields are used in qwc, when loading from editConfig (like in the AttributeTable, where it is also loaded from the editConfig).